### PR TITLE
build: update app-id and release 46.0

### DIFF
--- a/app.devsuite.Schemes.json
+++ b/app.devsuite.Schemes.json
@@ -1,7 +1,7 @@
 {
-    "app-id" : "me.hergert.Schemes",
+    "app-id" : "app.devsuite.Schemes",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "schemes",
     "finish-args" : [
@@ -32,8 +32,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/libpanel/1.2/libpanel-1.2.0.tar.xz",
-                    "sha256" : "d9055bbbab9625f3f5ce6d1fd7132eb6ea34a6ba07a87e9938901fb8b31581e2",
+                    "url" : "https://download.gnome.org/sources/libpanel/1.6/libpanel-1.6.0.tar.xz",
+                    "sha256" : "b773494a3c69300345cd8e27027448d1189183026cc137802f886417c6ea30b6",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libpanel",
@@ -52,7 +52,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/chergert/schemes.git",
-                    "commit" : "ede21dae6b28591bd9312f98f5899968de1f7277"
+                    "commit" : "a3971b955e22395d404e9b5aaee046d4dab251a0"
                 }
             ]
         }


### PR DESCRIPTION
This updates the app-id to match the movement to app.devsuite. for my applications and moves deps/app to 46.0 tag.